### PR TITLE
remove tailscale from systemPackage - already module

### DIFF
--- a/docs/02-tech-stack/nixos/configuration.nix.md
+++ b/docs/02-tech-stack/nixos/configuration.nix.md
@@ -50,7 +50,6 @@
     nvme-cli
     sanoid
     snapraid
-    tailscale
     tdns-cli
     tmux
     tree


### PR DESCRIPTION
since the tailscale NixOS module is enabled, i.e. `services.tailscale.enable = true;`, we do not need it installed via systemPackage. It's a redundant declaration.